### PR TITLE
Fix CI error caused by broken package

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,8 @@ set -e
 
 # Install system dependencies
 sudo dpkg --add-architecture i386
-sudo apt update
-sudo apt install -y --no-install-recommends \
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
   dpkg \
   fakeroot \
   libasound2 \
@@ -22,7 +22,9 @@ sudo apt install -y --no-install-recommends \
   wine \
   wine32 \
   wine64 \
-  zip
+  zip \
+  libgcc-s1:i386 \
+  libstdc++6:i386
 
 # Install NVM via cURL
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash


### PR DESCRIPTION
This PR fixes [the CI error](https://github.com/agustinmista/positron/actions/runs/5415198576/jobs/9844820405) caused while running the setup script where some packages ended up with unmet dependencies. Installing the packages explicitly fixed the error.